### PR TITLE
Add support for command to get the status

### DIFF
--- a/internal/pkg/client/application_client.go
+++ b/internal/pkg/client/application_client.go
@@ -98,3 +98,18 @@ func (c *cliClient) DeleteApp(appId string) error {
 
 	return nil
 }
+
+func (c *cliClient) GetApplicationStatus(appId string) (string, error) {
+	pathApplicationStatus := pathApplications + "/state/" + appId
+	var stateResponse struct {
+		Id     string `json:"id"`
+		Entity int    `json:"entity"`
+		Kind   string `json:"value"`
+	}
+	err := c.httpClient.getRestResource(pathApplicationStatus, &stateResponse)
+	if err != nil {
+		return "", err
+	}
+
+	return stateResponse.Kind, nil
+}

--- a/internal/pkg/cmd/application/application.go
+++ b/internal/pkg/cmd/application/application.go
@@ -27,5 +27,6 @@ func NewApplicationCommand(cliContext runtime.CliContext) *cobra.Command {
 	cmd.AddCommand(NewDeployCommand(cliContext))
 	cmd.AddCommand(NewLogsCommand(cliContext))
 	cmd.AddCommand(NewDeleteCommand(cliContext))
+	cmd.AddCommand(NewStatusCommand(cliContext))
 	return cmd
 }

--- a/internal/pkg/cmd/application/commons.go
+++ b/internal/pkg/cmd/application/commons.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 Inc. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package application
+
+import (
+	"github.com/wso2/choreo-cli/internal/pkg/client"
+	"github.com/wso2/choreo-cli/internal/pkg/cmd/common"
+	"github.com/wso2/choreo-cli/internal/pkg/cmd/runtime"
+)
+
+func failIfUserNotLoggedIn(cliContext runtime.CliContext) {
+	if !client.IsUserLoggedIn(cliContext) {
+		common.ExitWithErrorMessage(cliContext.Out(), "Please login first")
+	}
+}

--- a/internal/pkg/cmd/application/create.go
+++ b/internal/pkg/cmd/application/create.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/wso2/choreo-cli/internal/pkg/client"
 	"github.com/wso2/choreo-cli/internal/pkg/cmd/common"
 	"github.com/wso2/choreo-cli/internal/pkg/cmd/runtime"
 )
@@ -36,9 +35,7 @@ func NewCreateCommand(cliContext runtime.CliContext) *cobra.Command {
 
 func createAppCreateCommand(cliContext runtime.CliContext) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
-		if !client.IsUserLoggedIn(cliContext) {
-			common.ExitWithErrorMessage(cliContext.Out(), "Please login first")
-		}
+		failIfUserNotLoggedIn(cliContext)
 
 		description, err := cmd.Flags().GetString(descriptionFlagName)
 		if err != nil {

--- a/internal/pkg/cmd/application/deploy.go
+++ b/internal/pkg/cmd/application/deploy.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/wso2/choreo-cli/internal/pkg/client"
 	"github.com/wso2/choreo-cli/internal/pkg/cmd/common"
 	"github.com/wso2/choreo-cli/internal/pkg/cmd/runtime"
 )
@@ -34,12 +33,10 @@ func NewDeployCommand(cliContext runtime.CliContext) *cobra.Command {
 
 func runDeployAppCommand(cliContext runtime.CliContext) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
-		if !client.IsUserLoggedIn(cliContext) {
-			common.ExitWithErrorMessage(cliContext.Out(), "Please login first")
-		}
+		failIfUserNotLoggedIn(cliContext)
 
 		appName, err := cmd.Flags().GetString("name")
-		if err !=nil {
+		if err != nil {
 			common.ExitWithError(cliContext.Out(), "Error while reading the application name flag value", err)
 		}
 

--- a/internal/pkg/cmd/application/list.go
+++ b/internal/pkg/cmd/application/list.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/landoop/tableprinter"
 	"github.com/spf13/cobra"
-	"github.com/wso2/choreo-cli/internal/pkg/client"
 	"github.com/wso2/choreo-cli/internal/pkg/cmd/common"
 	"github.com/wso2/choreo-cli/internal/pkg/cmd/runtime"
 )
@@ -35,9 +34,7 @@ func NewListCommand(cliContext runtime.CliContext) *cobra.Command {
 func runListAppCommand(cliContext runtime.CliContext) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 
-		if !client.IsUserLoggedIn(cliContext) {
-			common.ExitWithErrorMessage(cliContext.Out(), "Please login first")
-		}
+		failIfUserNotLoggedIn(cliContext)
 
 		apps, err := cliContext.Client().ListApps()
 		if err == nil {

--- a/internal/pkg/cmd/application/status.go
+++ b/internal/pkg/cmd/application/status.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 Inc. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package application
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/choreo-cli/internal/pkg/cmd/common"
+	"github.com/wso2/choreo-cli/internal/pkg/cmd/runtime"
+)
+
+func NewStatusCommand(cliContext runtime.CliContext) *cobra.Command {
+	const cmdStatus = "status"
+	cmd := &cobra.Command{
+		Use:   cmdStatus + " APP_ID",
+		Short: "Get status of an application",
+		Example: fmt.Sprint(common.GetAbsoluteCommandName(cmdApplication, cmdStatus),
+			" app2bb24a9488fc46b05212eac1db9dcc81"),
+		Args: cobra.ExactArgs(1),
+		Run:  runAppStatusCommand(cliContext),
+	}
+	return cmd
+}
+
+func runAppStatusCommand(cliContext runtime.CliContext) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		failIfUserNotLoggedIn(cliContext)
+
+		status, err := cliContext.Client().GetApplicationStatus(args[0])
+		if err != nil {
+			common.ExitWithError(cliContext.Out(), "error occurred while retrieving status of the application", err)
+		} else {
+			common.PrintInfo(cliContext.Out(), status)
+		}
+	}
+}

--- a/internal/pkg/cmd/application/status_test.go
+++ b/internal/pkg/cmd/application/status_test.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 Inc. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package application
+
+import (
+	"bytes"
+	cl "github.com/wso2/choreo-cli/internal/pkg/client"
+	"github.com/wso2/choreo-cli/internal/pkg/test/mock/client"
+	"github.com/wso2/choreo-cli/internal/pkg/test/mock/config"
+	"github.com/wso2/choreo-cli/internal/pkg/test/mock/runtime"
+	"testing"
+
+	"github.com/wso2/choreo-cli/internal/pkg/test"
+)
+
+func TestStatusCommand(t *testing.T) {
+	var b bytes.Buffer
+	deployCommand := NewStatusCommand(&runtime.MockCliContext{
+		MockOut:        &b,
+		MockUserConfig: config.NewMockConfigHolder(map[string]string{cl.AccessToken: "some-token"}),
+		MockEnvConfig:  config.NewMockConfigHolder(map[string]string{}),
+		MockClient: &client.MockClient{GetStatus_: func(appId string) (status string, e error) {
+			return "CREATED", nil
+		}},
+	})
+	deployCommand.Run(nil, []string{"appe2c355af699438c01f17742065a4f950"})
+
+	expect := "CREATED" + "\n"
+	test.AssertString(t, expect, b.String(), "Status command output is not as expected")
+}

--- a/internal/pkg/cmd/runtime/context.go
+++ b/internal/pkg/cmd/runtime/context.go
@@ -75,6 +75,7 @@ type ApplicationApiClient interface {
 	CreateAndDeployAppWithName(appName, repoUrl string) (DeploymentDetails, error)
 	FetchLogs(appId string, linesCount uint) (string, error)
 	DeleteApp(appId string) error
+	GetApplicationStatus(appId string) (string, error)
 }
 
 type AuthApiClient interface {

--- a/internal/pkg/test/mock/client/client.go
+++ b/internal/pkg/test/mock/client/client.go
@@ -19,6 +19,7 @@ type MockClient struct {
 	FetchLogs_                  func(appId string, linesCount uint) (string, error)
 	CreateOauthStateString_     func() (string, error)
 	DeleteApp_                  func(appId string) error
+	GetStatus_                  func(appId string) (string, error)
 }
 
 func (c *MockClient) CreateNewApp(name string, desc string) error {
@@ -74,4 +75,11 @@ func (c *MockClient) DeleteApp(appId string) error {
 		return c.DeleteApp_(appId)
 	}
 	return nil
+}
+
+func (c *MockClient) GetApplicationStatus(appId string) (string, error) {
+	if c.GetStatus_ != nil {
+		return c.GetStatus_(appId)
+	}
+	return "", nil
 }


### PR DESCRIPTION
## Describe your problem(s)
The current status of the application cannot be retrieved

## Describe your solution
The status of the app can be obtained by the

`chor app status APP_ID` command

Related issue: https://github.com/wso2/choreo/issues/288

## Checklist

- [x] Unit tests
- [x] Documentation
- [x] Updated release note
