### PR TITLE
Allow specifying the app id with the deploy command

### DIFF
--- a/internal/pkg/client/application_client.go
+++ b/internal/pkg/client/application_client.go
@@ -18,11 +18,6 @@ const pathApplications = "/applications"
 const pathApplicationDeployment = pathApplications + "/deployments"
 const pathApplicationLogs = pathApplications + "/logs"
 
-type appDeploymentRequest struct {
-	AppName string `json:"name"`
-	RepoUrl string `json:"repo_url"`
-}
-
 func (c *cliClient) ListApps() ([]runtime.Application, error) {
 	var apps []runtime.Application
 
@@ -47,27 +42,11 @@ func (c *cliClient) CreateNewApp(name string, desc string) error {
 	return nil
 }
 
-func (c *cliClient) CreateAndDeployApp(repoUrl string) (runtime.DeploymentDetails, error) {
-	deploymentRequest := appDeploymentRequest{
-		RepoUrl: repoUrl,
-	}
+func (c *cliClient) CreateAndDeployApp(deploymentRequest runtime.DeploymentInput) (runtime.DeploymentOut, error) {
 
-	var deploymentDetails runtime.DeploymentDetails
+	var deploymentDetails runtime.DeploymentOut
 
-	err := c.httpClient.createRestResourceWithResponse(pathApplicationDeployment, &deploymentRequest, &deploymentDetails)
-
-	return deploymentDetails, err
-}
-
-func (c *cliClient) CreateAndDeployAppWithName(appName, repoUrl string) (runtime.DeploymentDetails, error) {
-	deploymentRequest := appDeploymentRequest{
-		AppName: appName,
-		RepoUrl: repoUrl,
-	}
-
-	var deploymentDetails runtime.DeploymentDetails
-
-	err := c.httpClient.createRestResourceWithResponse(pathApplicationDeployment, &deploymentRequest, &deploymentDetails)
+	err := c.httpClient.createRestResourceWithResponse(pathApplicationDeployment, deploymentRequest, &deploymentDetails)
 
 	return deploymentDetails, err
 }

--- a/internal/pkg/client/application_client_test.go
+++ b/internal/pkg/client/application_client_test.go
@@ -107,7 +107,7 @@ func TestDeployAppError(t *testing.T) {
 		},
 	}
 
-	_, err := client.CreateAndDeployApp("http://github.com/test/test")
+	_, err := client.CreateAndDeployApp(runtime.DeploymentInput{Url: "http://github.com/test/test"})
 
 	test.AssertNonNil(t, err, "An error should be returned")
 }
@@ -120,7 +120,7 @@ func TestDeployApp(t *testing.T) {
 		httpClient: &mockHttpClient{
 			createRestResourceWithResponseImpl: func(resourcePath string, requestData interface{},
 				responseData interface{}) error {
-				apps := responseData.(*runtime.DeploymentDetails)
+				apps := responseData.(*runtime.DeploymentOut)
 				apps.DeploymentUrl = "http://example.com/apps/url"
 				apps.ApplicationId = "appd83d56f4c6ff40428e8dd057c5b94bd5"
 				return nil
@@ -128,7 +128,7 @@ func TestDeployApp(t *testing.T) {
 		},
 	}
 
-	deploymentDetails, _ := client.CreateAndDeployApp("http://github.com/test/test")
+	deploymentDetails, _ := client.CreateAndDeployApp(runtime.DeploymentInput{Url: "http://github.com/test/test"})
 
 	test.AssertString(t, "http://example.com/apps/url", deploymentDetails.DeploymentUrl,
 		"The app URL should be returned")

--- a/internal/pkg/cmd/runtime/context.go
+++ b/internal/pkg/cmd/runtime/context.go
@@ -63,7 +63,14 @@ type ApplicationRequest struct {
 	Description string `json:"description" header:"Description"`
 }
 
-type DeploymentDetails struct {
+type DeploymentInput struct {
+	Url           string `json:"repo_url"`
+	ApplicationId string `json:"app_id"`
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+}
+
+type DeploymentOut struct {
 	DeploymentUrl string `json:"deployment_url"`
 	ApplicationId string `json:"app_id"`
 }
@@ -71,8 +78,7 @@ type DeploymentDetails struct {
 type ApplicationApiClient interface {
 	CreateNewApp(name string, desc string) error
 	ListApps() ([]Application, error)
-	CreateAndDeployApp(repoUrl string) (DeploymentDetails, error)
-	CreateAndDeployAppWithName(appName, repoUrl string) (DeploymentDetails, error)
+	CreateAndDeployApp(deploymentRequest DeploymentInput) (DeploymentOut, error)
 	FetchLogs(appId string, linesCount uint) (string, error)
 	DeleteApp(appId string) error
 	GetApplicationStatus(appId string) (string, error)

--- a/internal/pkg/test/mock/client/client.go
+++ b/internal/pkg/test/mock/client/client.go
@@ -12,14 +12,13 @@ package client
 import "github.com/wso2/choreo-cli/internal/pkg/cmd/runtime"
 
 type MockClient struct {
-	CreateNewApp_               func(name string, desc string) error
-	ListApps_                   func() ([]runtime.Application, error)
-	CreateAndDeployApp_         func(repoUrl string) (runtime.DeploymentDetails, error)
-	CreateAndDeployAppWithName_ func(appId, repoUrl string) (runtime.DeploymentDetails, error)
-	FetchLogs_                  func(appId string, linesCount uint) (string, error)
-	CreateOauthStateString_     func() (string, error)
-	DeleteApp_                  func(appId string) error
-	GetStatus_                  func(appId string) (string, error)
+	CreateNewApp_           func(name string, desc string) error
+	ListApps_               func() ([]runtime.Application, error)
+	CreateAndDeployApp_     func(deploymentRequest runtime.DeploymentInput) (runtime.DeploymentOut, error)
+	FetchLogs_              func(appId string, linesCount uint) (string, error)
+	CreateOauthStateString_ func() (string, error)
+	DeleteApp_              func(appId string) error
+	GetStatus_              func(appId string) (string, error)
 }
 
 func (c *MockClient) CreateNewApp(name string, desc string) error {
@@ -36,21 +35,11 @@ func (c *MockClient) ListApps() ([]runtime.Application, error) {
 	return nil, nil
 }
 
-func (c *MockClient) CreateAndDeployApp(repoUrl string) (runtime.DeploymentDetails, error) {
+func (c *MockClient) CreateAndDeployApp(deploymentRequest runtime.DeploymentInput) (runtime.DeploymentOut, error) {
 	if c.CreateAndDeployApp_ != nil {
-		return c.CreateAndDeployApp_(repoUrl)
+		return c.CreateAndDeployApp_(deploymentRequest)
 	}
-	return runtime.DeploymentDetails{
-		DeploymentUrl: "",
-		ApplicationId: "",
-	}, nil
-}
-
-func (c *MockClient) CreateAndDeployAppWithName(appId, repoUrl string) (runtime.DeploymentDetails, error) {
-	if c.CreateAndDeployAppWithName_ != nil {
-		return c.CreateAndDeployAppWithName_(appId, repoUrl)
-	}
-	return runtime.DeploymentDetails{
+	return runtime.DeploymentOut{
 		DeploymentUrl: "",
 		ApplicationId: "",
 	}, nil


### PR DESCRIPTION
## Describe your problem(s)
Cannot associate the created app to a deployed url

## Describe your solution
Allow specifying the app id with the deploy command
chor app deploy [APP_ID] url

## Checklist

- [x] Unit tests
- [x] Documentation
- [x] Updated release note
